### PR TITLE
Update GT4Py dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 ]
 dependencies = [
     # note(stubbiali): specify commit hash until #1462 is available in a public release
-    'gt4py[dace] @ git+https://github.com/GridTools/gt4py.git@2cd0c91',
+    'gt4py>=1.0.4',
     'numpy>=1.22',
     'pydantic<2.0',
     'sympl @ git+https://github.com/stubbiali/sympl.git@oop'


### PR DESCRIPTION
For the porting of the ecRad radiation scheme, we need the support for for-loops over data dimensions (from [this branch](https://github.com/stubbiali/gt4py/tree/loops-over-data-dims)).

This requires `gt4py>=1.0.4`, which is why we update the dependency in the `pyproject.toml`.